### PR TITLE
Fix auto-require of linea gem

### DIFF
--- a/lib/linea.rb
+++ b/lib/linea.rb
@@ -1,0 +1,1 @@
+require "linea/rails"


### PR DESCRIPTION
Hey. I noticed that the gem was lacking a `lib/linea.rb` file, which caused it not to be auto-required by Rails, so I added one.