### PR TITLE
Fix font paths

### DIFF
--- a/app/assets/stylesheets/icons/_arrows.scss
+++ b/app/assets/stylesheets/icons/_arrows.scss
@@ -1,4 +1,4 @@
-$icon_arrows_path:                                   '/arrows/';
+$icon_arrows_path:                                   'arrows/';
 $icon_arrows_name:                                   'linea-arrows-10';
 $icon_arrows_short:                                  'arrows';
 

--- a/app/assets/stylesheets/icons/_basic.scss
+++ b/app/assets/stylesheets/icons/_basic.scss
@@ -1,4 +1,4 @@
-$icon_basic_path:                                   '/basic/';
+$icon_basic_path:                                   'basic/';
 $icon_basic_name:                                   'linea-basic-10';
 $icon_basic_short:                                  'basic';
 

--- a/app/assets/stylesheets/icons/_basic_elaboration.scss
+++ b/app/assets/stylesheets/icons/_basic_elaboration.scss
@@ -1,4 +1,4 @@
-$icon_basic-elaboration_path:                       '/basic_elaboration/';
+$icon_basic-elaboration_path:                       'basic_elaboration/';
 $icon_basic-elaboration_name:                       'linea-basic-elaboration-10';
 $icon_basic-elaboration_short:                      'basic-elaboration';
 

--- a/app/assets/stylesheets/icons/_ecommerce.scss
+++ b/app/assets/stylesheets/icons/_ecommerce.scss
@@ -1,4 +1,4 @@
-$icon_ecommerce_path:                                   '/ecommerce/';
+$icon_ecommerce_path:                                   'ecommerce/';
 $icon_ecommerce_name:                                   'linea-ecommerce-10';
 $icon_ecommerce_short:                                  'ecommerce';
 

--- a/app/assets/stylesheets/icons/_music.scss
+++ b/app/assets/stylesheets/icons/_music.scss
@@ -1,4 +1,4 @@
-$icon_music_path:                                   '/music/';
+$icon_music_path:                                   'music/';
 $icon_music_name:                                   'linea-music-10';
 $icon_music_short:                                  'music';
 

--- a/app/assets/stylesheets/icons/_software.scss
+++ b/app/assets/stylesheets/icons/_software.scss
@@ -1,4 +1,4 @@
-$icon_software_path:                                   '/software/';
+$icon_software_path:                                   'software/';
 $icon_software_name:                                   'linea-software-10';
 $icon_software_short:                                  'software';
 

--- a/app/assets/stylesheets/icons/_weather.scss
+++ b/app/assets/stylesheets/icons/_weather.scss
@@ -1,4 +1,4 @@
-$icon_weather_path:                                   '/weather/';
+$icon_weather_path:                                   'weather/';
 $icon_weather_name:                                   'linea-weather-10';
 $icon_weather_short:                                  'weather';
 


### PR DESCRIPTION
Font paths were all absolute, which caused `font-url()` to not use the right assets prefix of (e.g. `assets/`), and so the fonts couldn't be found. This was rendering the gem unusable.